### PR TITLE
output: updated lb type and proper interpolation

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "dns_name" {
   description = "DNS Name of the master load balancer"
-  value       = "${length(var.instances) < 1 ? "" : aws_lb.loadbalancer.0.dns_name}"
+  value       = "${length(var.instances) < 1 ? "" : join(",", aws_lb.loadbalancer.*.dns_name)}"
 }


### PR DESCRIPTION
Terraform was throwing errors because it could not process aws_lb.loadbalancer.0.dns_name. It also couldn't know what type this was. By passing in the join function, it knew that it can only return a string

This effort is for testing out the 0.2.0 release of the Universal Installer using dcos-ansible