### PR TITLE
length of aws_lb_target_group, wrong condition = true value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ resource "aws_lb_target_group" "targetgroup" {
   count    = "${var.disable ? 0 : length(local.concat_listeners)}"
   port     = "${lookup(local.concat_listeners[count.index], "port")}"
   protocol = "${upper(lookup(local.concat_listeners[count.index], "protocol", var.load_balancer_type == "application" ? "http" : "tcp"))}"
-  name     = "${substr(local.elb_name,0, length(local.elb_name) >= 24 ? 24 : length(local.elb_name) )}-tg-${lookup(local.concat_listeners[count.index], "port")}"
+  name     = "${substr(local.elb_name,0, length(local.elb_name) >= 24 ? 23 : length(local.elb_name) )}-tg-${lookup(local.concat_listeners[count.index], "port")}"
   tags     = "${merge(var.tags, map("Name", format(var.elb_name_format,local.cluster_name),
                                     "Cluster", local.cluster_name) )}"
 


### PR DESCRIPTION
- the true value for the condition that `length(local.elb_name) >= 24` was wrong (`24`)
- correct value ist `23` as a port with 5 digits would otherwise makes the overall name to long if `24` is used.

E.g.: `thisisalongnamefortheclu-tg-12342` cut is with `thisisalongnamefortheclu` 24 chars and adding the `-tg-12342`9 chars would extend the whole string to 33 chars, which will break. So a cut of `23` chars is needed here.