### PR TITLE
Self-signed certs should support OSX 10.15

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "tls_self_signed_cert" "selfsigned" {
     organization = "Mesosphere Inc."
   }
 
-  validity_period_hours = 85440
+  validity_period_hours = 19800
 
   allowed_uses = [
     "key_encipherment",
@@ -58,9 +58,13 @@ resource "tls_self_signed_cert" "selfsigned" {
 
 resource "aws_iam_server_certificate" "selfsigned" {
   count            = "${var.disable ? 0 : 1}"
-  name             = "${format(var.elb_name_format,local.cluster_name)}-cert"
+  name             = "${format(var.elb_name_format,local.cluster_name)}-cert-${element(tls_self_signed_cert.selfsigned.*.validity_start_time,0)}"
   certificate_body = "${element(tls_self_signed_cert.selfsigned.*.cert_pem,0)}"
   private_key      = "${element(tls_private_key.selfsigned.*.private_key_pem,0)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 data "aws_subnet" "selected" {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "tls_self_signed_cert" "selfsigned" {
 
 resource "aws_iam_server_certificate" "selfsigned" {
   count            = "${var.disable ? 0 : 1}"
-  name             = "${format(var.elb_name_format,local.cluster_name)}-cert-${element(tls_self_signed_cert.selfsigned.*.validity_start_time,0)}"
+  name             = "${format(var.elb_name_format,local.cluster_name)}-cert-${replace(element(tls_self_signed_cert.selfsigned.*.validity_start_time,0), "/[:+.]/", "-")}"
   certificate_body = "${element(tls_self_signed_cert.selfsigned.*.cert_pem,0)}"
   private_key      = "${element(tls_private_key.selfsigned.*.private_key_pem,0)}"
 


### PR DESCRIPTION
this could be partially considered as breaking change but in general the server_cert gets first recreated and the load balancer reference will change before the old cert gets destroyed.

This patch applies a shorter lifetime to the self-signed cert as described here https://support.apple.com/en-us/HT210176 it also makes it easier for users to rotate the self signed cert before it is getting invalid:

```bash
# rotate masters self signed cert
terraform taint -module dcos.dcos-infrastructure.dcos-lb.dcos-lb-masters.masters tls_self_signed_cert.selfsigned

# rotate public agents self signed
terraform taint -module dcos.dcos-infrastructure.dcos-lb.dcos-lb-public-agents.public-agents tls_self_signed_cert.selfsigned
```

https://jira.mesosphere.com/browse/DCOS-60264

- rename aws_iam_server_certificate to contain validity_start_time
- change life cycle of aws_iam_server_certificate
- self-signed cert lifetime 825 days