### PR TITLE
fix: use try on variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_iam_server_certificate" "selfsigned" {
 }
 
 data "aws_subnet" "selected" {
-  id = element(var.subnet_ids, 0)
+  id = try(element(var.subnet_ids, 0), "")
 }
 
 // Only 32 characters allowed for name. So we have to use substring


### PR DESCRIPTION
it seems in some weird situations where the actual resources might be gone but state still exists we ran into an error like:

```
Call to function "element" failed: cannot use element function with an empty
list.
```

lets use try in this situation but its actually not allowed having that subnet list be empty
